### PR TITLE
fix package-manager PATH for node-runner image

### DIFF
--- a/skel/.env
+++ b/skel/.env
@@ -5,7 +5,7 @@ export VISUAL=vim
 
 export PATH="${HOME}/bin:${PATH}"
 export PATH="${HOME}/.local/bin:$PATH"
-export PATH="${PATH}:${HOME}/.corepack/bin:${HOME}/.npm-global/bin"
+export PATH="${HOME}/.corepack/bin:${HOME}/.npm-global/bin:${PATH}"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1


### PR DESCRIPTION
Ensures corepack package managers are preferred instead of base image `yarn`