### PR TITLE
nodejs trust caddy

### DIFF
--- a/contrib/bin/l7-cnt-run
+++ b/contrib/bin/l7-cnt-run
@@ -38,6 +38,8 @@ sudo -E \
   podman run --rm -i \
   --user "$(id -u):$(id -g)" --userns=keep-id:uid=$(id -u),gid=$(id -g) \
   -e '*' \
+  --network "${L7_COMPOSE_NETWORK_NAME_INTERNAL}" \
   -v "${SRC_DIR}:${SRC_DIR}" -v "${SRC_DIR}:/src" -w "${PWD}" \
+  -v "${L7_RESOLV_CONF_PATH}:/etc/resolv.conf:ro" \
   ${RUNNER_OPTS} \
   --entrypoint "${COMMAND}" -- $RUNNER_IMAGE ${ARGS}

--- a/devenv.sh
+++ b/devenv.sh
@@ -162,6 +162,8 @@ ${cmd} run --rm -it \
   -v "${RESOLV_CONF_PATH}:/etc/resolv.conf:ro" \
   -w "${CWD}" \
   --mount type=tmpfs,tmpfs-size=2G,destination=/tmp,U=true,tmpfs-mode=0777 \
+  -e "L7_COMPOSE_NETWORK_NAME_INTERNAL=$(get_compose_network_name 'internal')" \
+  -e "L7_RESOLV_CONF_PATH=${RESOLV_CONF_PATH}" \
   -e "CONTAINER_HOST=unix:///run/docker.sock" \
   -e GO_RUNNER_IMAGE=localhost/l7/go:1.20-bookworm \
   -e NODE_RUNNER_IMAGE=localhost/l7/node:20-bookworm \

--- a/sidecars/node-runner/Containerfile
+++ b/sidecars/node-runner/Containerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG NODE_VERSION=20
+FROM localhost/l7/caddy:latest AS fwdproxy
 FROM docker.io/node:${NODE_VERSION}-bookworm-slim
 
 RUN apt-get update \
@@ -32,7 +33,15 @@ COPY sidecars/node-runner/package.json \
 RUN npm ci --omit=dev --ignore-scripts \
   && mv node_modules/* node_modules/.bin /usr/local/lib/node_modules/
 
+COPY --from=fwdproxy \
+  /data/caddy/pki/authorities/local/root.crt \
+  # note: the .crt ending is important
+  /usr/local/share/ca-certificates/l7-fwd-proxy.crt
+
+RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure ca-certificates
+
 ####
+
 USER ${UID}:${GID}
 ENV HOME=/home/node
 # fix broken ipv6 on nodejs v20
@@ -54,8 +63,7 @@ RUN ./install-package-managers.sh \
 
 ENV SHELL=${SHELL}
 
-COPY contrib/l*-scripts/bin/*      /usr/local/bin/
-
+COPY contrib/l*-scripts/bin/*    /usr/local/bin/
 COPY --chown=${UID}:${GID} skel/ /home/node/
 
 ENV PATH=/home/node/.corepack/bin:${PATH}


### PR DESCRIPTION
- **gitconfig: add submodule aliases**
- **chore: dependabot config**
- **ci: remove ineffective codeql**
- **ci: make test for caddy, dnsmasq**
- **make: use bash**
- **node-runner: trust caddy root cert**
