### PR TITLE
feat: remote-share desktop with tunneled VNC web-viewer

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -166,6 +166,7 @@ services:
     entrypoint: xterm
 #########################################################
 
+
 volumes:
   user_local:
     name: l7_dev_user_local

--- a/compose/vnc.compose.yml
+++ b/compose/vnc.compose.yml
@@ -60,6 +60,25 @@ services:
       # vnc
       - '5902:5902'
 
+  novnc:
+    depends_on:
+      - vnc
+    profiles:
+      - vnc
+      - remote
+    build:
+      context: ../imags/X11/novnc
+      dockerfile: Containerfile
+    image: 'localhost/l7/novnc:latest'
+    restart: always
+    command: '--listen 6080 --vnc 10.7.9.50:5902'
+    hostname: localhost
+    networks:
+      vnc:
+        ipv4_address: 10.7.9.51
+    ports:
+      - '6080:6080'
+
 ########
 
 networks:

--- a/compose/vnc.compose.yml
+++ b/compose/vnc.compose.yml
@@ -79,6 +79,22 @@ services:
     ports:
       - '6080:6080'
 
+  ssh-proxy:
+    depends_on:
+      - novnc
+    profiles:
+      - vnc
+      - remote
+    build:
+      context: ../imags/ssh-proxy
+      dockerfile: Containerfile
+    image: 'localhost/l7/ssh-proxy:latest'
+    command: '-p443 -R0:10.7.9.51:6080 -o ServerAliveInterval=30 tls@a.pinggy.io'
+    hostname: localhost
+    networks:
+      public:
+      vnc:
+
 ########
 
 networks:

--- a/imags/X11/novnc/Containerfile
+++ b/imags/X11/novnc/Containerfile
@@ -1,0 +1,19 @@
+ARG ALPINE_VERSION=3.20
+FROM docker.io/alpine:${ALPINE_VERSION}
+
+ARG CERT_VALIDITY_DAYS="365"
+ARG CERT_SUBJECT="/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=example.com"
+
+RUN apk add --no-cache \
+      novnc \
+      openssl \
+    # Prebaked key and cert for convenience; mounting at runtime can be better
+    && mkdir /keys \
+    && openssl req -new -x509 -nodes \
+      -days "${CERT_VALIDITY_DAYS}" \
+      -subj "${CERT_SUBJECT}" \
+      -out /keys/novnc.pem \
+      -keyout /keys/novnc-private.pem \
+    && openssl x509 -in /keys/novnc.pem
+
+ENTRYPOINT ["novnc_server", "--key", "/keys/novnc-private.pem", "--cert", "/keys/novnc.pem", "--ssl-only"]

--- a/imags/node-runner/Containerfile
+++ b/imags/node-runner/Containerfile
@@ -71,7 +71,7 @@ WORKDIR /tmp
 
 COPY imags/node-runner/install-package-managers.sh .
 # TODO: integrity checksums / sigchecks for bundled PMs
-ARG COREPACK_PMS='npm@10.8.2 npm@10 npm@6.14.18 npm@6 npm@7.24.2 npm@7 npm@9.9.3 npm@9 pnpm@8.15.8 pnpm@8 pnpm@9.4 pnpm@9.5.0 pnpm@9 yarn@1.22.22 yarn@1 yarn@3.2.1 yarn@3.2.2 yarn@3.4.1 yarn@3.5.1 yarn@3.6.0 yarn@3.6.2 yarn@3 yarn@4.1.1 yarn@4.2.2 yarn@4.3.1 yarn@4'
+ARG COREPACK_PMS='npm@10.8.1 npm@10.8.2 npm@10 npm@6.14.18 npm@6 npm@7.24.2 npm@7 npm@9.9.3 npm@9 pnpm@8.15.8 pnpm@8 pnpm@9.4 pnpm@9.5.0 pnpm@9 yarn@1.22.22 yarn@1 yarn@3.2.1 yarn@3.2.2 yarn@3.4.1 yarn@3.5.1 yarn@3.6.0 yarn@3.6.2 yarn@3 yarn@4.1.1 yarn@4.2.2 yarn@4.3.1 yarn@4'
 
 ENV PATH=/usr/local/lib/node_modules/.bin:/usr/local/lib/node_modules/corepack/shims:${HOME}/.cache/node/corepack/v1/npm:${HOME}/.corepack/bin:$PATH
 

--- a/imags/ssh-proxy/Containerfile
+++ b/imags/ssh-proxy/Containerfile
@@ -1,0 +1,14 @@
+ARG ALPINE_VERSION=3.20
+FROM docker.io/alpine:${ALPINE_VERSION}
+RUN apk add --no-cache \
+  autossh \
+  grep \
+  openssh \
+  sed
+COPY entrypoint.sh /
+#ARG SSH_KNOWN_HOSTS="serveo.net ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDxYGqSKVwJpQD1F0YIhz+bd5lpl7YesKjtrn1QD1RjQcSj724lJdCwlv4J8PcLuFFtlAA8AbGQju7qWdMN9ihdHvRcWf0tSjZ+bzwYkxaCydq4JnCrbvLJPwLFaqV1NdcOzY2NVLuX5CfY8VTHrps49LnO0QpGaavqrbk+wTWDD9MHklNfJ1zSFpQAkSQnSNSYi/M2J3hX7P0G2R7dsUvNov+UgNKpc4n9+Lq5Vmcqjqo2KhFyHP0NseDLpgjaqGJq2Kvit3QowhqZkK4K77AA65CxZjdDfpjwZSuX075F9vNi0IFpFkGJW9KlrXzI4lIzSAjPZBURhUb8nZSiPuzj"
+ARG SSH_KNOWN_HOSTS="[a.pinggy.io]:443 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDF0YJigZJU62vn4rsKGRjIRTtMe/suc3d4YDe0iIvFzLMuaN78oxhWn9Uqefe1gN++dYVssspsgsvTXTTBcxxo3WoFeNr1z/+osJ45+Yxoa0pbaJdAwbr8CqjDa96r9/AhAXHoKncAByEOSiXfdWCXf84YC+Hu48/gZOqSZ3VqPz+nNGFByJcqYJ+jSELSqCNWVLWFxx7vH270Kymw2XkdOW47zzDNO7X4uByxHfaZMgI6phoaNglGizM0VNMQPL5GbspVGejFQE85QJbX3oF8vuCYnM+OMkwopHG+muh6Tro8+fm6G/fcmu34YJNbU3oaTdW1YPqvcKFX1AuIY9CA5lLZR9A1rOJ+fd4JEYaoTxwUN2ZPcrf7JEnvHmcV9hmupTSllJzLk4smDpl5PSknDm68/h/z/ZmaDlunGsHnn397fwCwS7sO9Q1yIuZ+Bri0td7+N2EK1mvM/qsnrSauOymcmqYVy6TLiejHdoVl8+lKqatkTxyFf/3MP8ylCKSoP0SJZratcU1n+0EciG+IjEzdPZ/1tuJZhBWqOUbYfUl+WgovH+J+AQKtoNzPP+fLtLNcmLEhx99N2y5l7A8IOlyy41Minq4N7V5X8Q7QHhEoocatNNn5JRYe/25P9aQelF0ItMD0PEmf8rIHWMqbwnwQ8pVVdDhE6mwhDskBIw=="
+RUN echo "${SSH_KNOWN_HOSTS}" >> /etc/ssh/ssh_known_hosts
+# polling time in seconds; default 600
+ENV AUTOSSH_POLL=58
+ENTRYPOINT ["/entrypoint.sh"]

--- a/imags/ssh-proxy/entrypoint.sh
+++ b/imags/ssh-proxy/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+autossh \
+  -M 0\
+  -oExitOnForwardFailure=yes \
+  "${@}" \
+   | grep -o '^[a-z0-9]*://[^\s]*\.link$' \
+   | sed -e 's#^[a-z0-9]*#\n  *** VNC VIEWER EXPOSED ***\nYou can now share access by sharing:\nhttps#' \
+    -e 's#$#/vnc.html\n#'
+
+
+
+#   | grep -o '^[a-z0-9]*://[^\s]*' | sed -e 's#^[a-z0-9]*#\n  You can now share a remote view or control (depending on server authentication) via sharing:\nhttps#' -e 's#$#/vnc.html\n#'
+# TODO: something with ssh tty to make capturing output work


### PR DESCRIPTION
Enables easy screen sharing and/or remote control over internet via web browser.

- add novnc
  - web-view for vnc remoting
- add ssh-proxy
  - exposes novnc through external ssh proxy

TODO
- [ ] Add test
- [ ] Secure vnc connection through mTLS instead of vncpasswd